### PR TITLE
Fix directive declaration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ import './todo.scss';
 export const TodoModule = angular
   .module('todo', [])
   .component('todo', TodoComponent)
-  .directive('todoAutofocus', () => new TodoAutoFocus())
+  .directive('todoAutofocus', ($timeout) => new TodoAutoFocus($timeout))
   .name;
 ```
 

--- a/i18n/es.md
+++ b/i18n/es.md
@@ -653,7 +653,7 @@ import TodoAutofocus from './todo-autofocus.directive';
 const TodoModule = angular
   .module('todo', [])
   .component('todo', TodoComponent)
-  .directive('todoAutofocus', () => new TodoAutoFocus)
+  .directive('todoAutofocus', ($timeout) => new TodoAutoFocus($timeout))
   .name;
 
 export default TodoModule;

--- a/i18n/fr-fr.md
+++ b/i18n/fr-fr.md
@@ -609,7 +609,7 @@ import './todo.scss';
 export const TodoModule = angular
   .module('todo', [])
   .component('todo', TodoComponent)
-  .directive('todoAutofocus', () => new TodoAutoFocus)
+  .directive('todoAutofocus', ($timeout) => new TodoAutoFocus($timeout))
   .name;
 ```
 

--- a/i18n/id.md
+++ b/i18n/id.md
@@ -671,7 +671,7 @@ import TodoAutofocus from './todo-autofocus.directive';
 const TodoModule = angular
   .module('todo', [])
   .component('todo', TodoComponent)
-  .directive('todoAutofocus', () => new TodoAutoFocus)
+  .directive('todoAutofocus', ($timeout) => new TodoAutoFocus($timeout))
   .name;
 
 export default TodoModule;

--- a/i18n/it-it.md
+++ b/i18n/it-it.md
@@ -673,7 +673,7 @@ import './todo.scss';
 export const TodoModule = angular
   .module('todo', [])
   .component('todo', TodoComponent)
-  .directive('todoAutofocus', () => new TodoAutoFocus())
+  .directive('todoAutofocus', ($timeout) => new TodoAutoFocus($timeout))
   .name;
 ```
 

--- a/i18n/pt-pt.md
+++ b/i18n/pt-pt.md
@@ -671,7 +671,7 @@ import TodoAutofocus from './todo-autofocus.directive';
 const TodoModule = angular
   .module('todo', [])
   .component('todo', TodoComponent)
-  .directive('todoAutofocus', () => new TodoAutoFocus)
+  .directive('todoAutofocus', ($timeout) => new TodoAutoFocus($timeout))
   .name;
 
 export default TodoModule;

--- a/i18n/ru-ru.md
+++ b/i18n/ru-ru.md
@@ -671,7 +671,7 @@ import TodoAutofocus from './todo-autofocus.directive';
 const TodoModule = angular
   .module('todo', [])
   .component('todo', TodoComponent)
-  .directive('todoAutofocus', () => new TodoAutoFocus)
+  .directive('todoAutofocus', ($timeout) => new TodoAutoFocus($timeout))
   .name;
 
 export default TodoModule;

--- a/i18n/zh-cn.md
+++ b/i18n/zh-cn.md
@@ -688,7 +688,7 @@ import TodoAutofocus from './todo-autofocus.directive';
 const TodoModule = angular
   .module('todo', [])
   .component('todo', TodoComponent)
-  .directive('todoAutofocus', () => new TodoAutoFocus)
+  .directive('todoAutofocus', ($timeout) => new TodoAutoFocus($timeout))
   .name;
 
 export default TodoModule;

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -697,7 +697,7 @@ import { TodoAutofocus } from './todo-autofocus.directive';
 export const TodoModule = angular
   .module('todo', [])
   .component('todo', TodoComponent)
-  .directive('todoAutofocus', () => new TodoAutoFocus)
+  .directive('todoAutofocus', ($timeout: angular.ITimeoutService) => new TodoAutoFocus($timeout))
   .name;
 
 ```


### PR DESCRIPTION
When directive is declared with an arrow function, injected parameters must be provided as arguments of the arrow function, then forwarded to the directive constructor.

Fixes #160 